### PR TITLE
Bugfix/Fix Prompt Focus Loss

### DIFF
--- a/INFO.md
+++ b/INFO.md
@@ -28,24 +28,20 @@ Once a menu image is uploaded, we start the build process:
 
 ## Task List
 
-- ❌ Try re-implementing abort signal. The exception may not show in prod.
+- ❌ Generate images on demand by clicking on placeholder image.
+
+- ❌ Commit some default menu data with images (min 3).
+
+- ❌ Better prompts for menu question/answer (put instructions and menu data in the system prompt). Add a max output token limit: 2000.
 
 - ❌ Better photo prompts for image generation.
 
-- ❌ Generate images on demand by clicking on placeholder image?
-
-- ❌ Commit some default menu data (min 3).
+- ❌ Try re-implementing abort signal to cancel generation process. The exception may not show in prod.
 
 - ❌ Optional: Allow multiple images to be uploaded (max 3 total)
 
 - ❌ Optional: Do a traditional Google search if no images can be generated and use the top result to display. User must tap the placeholder image to consent to seeing images from the web.
 
-- ❌ Optional: Convert existing website to Next.js (openbrew website already has similar setup, use app router).
-
-  - Convert all api calls to server-side actions OR use cloud functions without needing to convert website and put requests behind a password check.
-
-  - This allows us to serve api requests publically.
-
-- ❌ Optional: Implement Vercel databases (save images/json on per user basis, user login required)
+- ❌ Optional: Implement cloud storage per user. Vercel databases (save images/json on per user basis, user login required)
 
   - Load menu data from k/v. Load images from Blob Store.

--- a/src/components/MenuPageForWeb.js
+++ b/src/components/MenuPageForWeb.js
@@ -43,6 +43,7 @@ const MenuPageForWeb = () => {
 
   return (
     <>
+      {/* Top banner */}
       <div className={styles.bannerPage}>
         <Banner
           title={data?.name}
@@ -57,7 +58,9 @@ const MenuPageForWeb = () => {
           <CommandPallet data={data} />
         </Banner>
       </div>
+      {/* Main body */}
       <div className={styles.page}>
+        <div style={{ position: "fixed" }}></div>
         {renderSections(data, renderSection)}
         <Total hasOrderInput={isOrderMenuVariant} />
       </div>

--- a/src/components/MenuPageForWeb.js
+++ b/src/components/MenuPageForWeb.js
@@ -60,7 +60,6 @@ const MenuPageForWeb = () => {
       </div>
       {/* Main body */}
       <div className={styles.page}>
-        <div style={{ position: "fixed" }}></div>
         {renderSections(data, renderSection)}
         <Total hasOrderInput={isOrderMenuVariant} />
       </div>

--- a/src/components/MenuPageForWeb.module.scss
+++ b/src/components/MenuPageForWeb.module.scss
@@ -45,3 +45,10 @@
     box-shadow: none;
   }
 }
+
+@media (max-width: 900px) {
+  .page {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}

--- a/src/components/MenuPageForWeb.module.scss
+++ b/src/components/MenuPageForWeb.module.scss
@@ -6,7 +6,7 @@
   padding-left: 2.25rem;
   padding-right: 2.25rem;
   padding-top: 2rem;
-  padding-bottom: 0;
+  padding-bottom: 18rem; // leaves room above prompt fold
   margin: auto;
   max-width: 50rem;
   background-color: var(--light);
@@ -29,12 +29,11 @@
 // Small screen
 @media (max-width: 900px) {
   .page {
-    margin: auto;
     width: 100%;
     max-width: 100%;
-    padding: 2.5rem;
-    padding-bottom: 0;
     padding-top: 0;
+    padding-left: 1rem;
+    padding-right: 1rem;
     box-shadow: none;
   }
   .bannerPage {
@@ -43,12 +42,5 @@
     max-width: 100%;
     padding: 0;
     box-shadow: none;
-  }
-}
-
-@media (max-width: 900px) {
-  .page {
-    padding-left: 1rem;
-    padding-right: 1rem;
   }
 }

--- a/src/components/MenuPageForWeb.module.scss
+++ b/src/components/MenuPageForWeb.module.scss
@@ -6,7 +6,7 @@
   padding-left: 2.25rem;
   padding-right: 2.25rem;
   padding-top: 2rem;
-  padding-bottom: 18rem; // leaves room above prompt fold
+  padding-bottom: 22rem; // leaves room above prompt fold
   margin: auto;
   max-width: 50rem;
   background-color: var(--light);

--- a/src/components/MenuSection.js
+++ b/src/components/MenuSection.js
@@ -88,8 +88,11 @@ export const MenuSection = ({ item, index, sectionName, hasOrderInput }) => {
               <h3 className={styles.name}>{translate(keys.ALLERGY)}</h3>
             </button>
           </div>
-          {/* Category */}
-          <p style={{ marginTop: "2rem" }} className={styles.description}>
+          {/* Selected detail description */}
+          <p
+            style={{ marginTop: "2rem", marginBottom: "1rem" }}
+            className={styles.description}
+          >
             {item[currentDetail]}
           </p>
         </span>

--- a/src/components/MenuSection.js
+++ b/src/components/MenuSection.js
@@ -90,10 +90,13 @@ export const MenuSection = ({ item, index, sectionName, hasOrderInput }) => {
           </div>
           {/* Selected detail description */}
           <p
-            style={{ marginTop: "2rem", marginBottom: "1rem" }}
+            style={{
+              alignItems: "center",
+              marginTop: "1rem",
+            }}
             className={styles.description}
           >
-            {item[currentDetail]}
+            {item[currentDetail] || "No info 😐"}
           </p>
         </span>
       </div>

--- a/src/components/MenuSectionForWeb.module.scss
+++ b/src/components/MenuSectionForWeb.module.scss
@@ -96,6 +96,7 @@
   font-family: var(--font-primary);
   width: 100%;
   min-height: 1.5rem;
+  // padding-bottom: 5rem;
 }
 
 .price {

--- a/src/components/MenuSectionForWeb.module.scss
+++ b/src/components/MenuSectionForWeb.module.scss
@@ -95,8 +95,7 @@
   word-wrap: break-word;
   font-family: var(--font-primary);
   width: 100%;
-  min-height: 1.5rem;
-  // padding-bottom: 5rem;
+  min-height: 3rem; // prevents shifting items downstream
 }
 
 .price {

--- a/src/components/Total.js
+++ b/src/components/Total.js
@@ -22,10 +22,12 @@ export default function Total({ hasOrderInput }) {
   }, 0);
 
   return (
-    <div className={styles.total}>
-      <PromptMenu />
-      {isOrder && <span className={styles.totalTitle}>Total:</span>}
-      {isOrder && <span className={styles.totalPrice}>${totalPrice}</span>}
+    <div className={styles.totalContainer}>
+      <div className={styles.total}>
+        <PromptMenu />
+        {isOrder && <span className={styles.totalTitle}>Total:</span>}
+        {isOrder && <span className={styles.totalPrice}>${totalPrice}</span>}
+      </div>
     </div>
   );
 }

--- a/src/components/Total.module.scss
+++ b/src/components/Total.module.scss
@@ -1,6 +1,7 @@
 .total {
   display: flex;
-  position: sticky;
+  position: fixed;
+  max-width: 50rem;
   width: 100%;
   min-height: 2rem;
   height: max-content;
@@ -10,8 +11,8 @@
   margin-top: 2.5rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
-  padding-left: 0;
-  padding-right: 0;
+  padding-left: 1rem;
+  padding-right: 1rem;
   bottom: 0;
   color: var(--secondary);
   background-color: var(--light);
@@ -41,6 +42,13 @@
   height: max-content;
 }
 
+// Medium screen
+@media (max-width: 900px) {
+  .total {
+    max-width: none;
+  }
+}
+
 // Small screen
 @media (max-width: 600px) {
   .searchContainer {
@@ -48,8 +56,7 @@
     width: 100%;
   }
   .total {
+    max-width: none;
     flex-direction: column;
-    margin-left: 0;
-    margin-right: 0;
   }
 }

--- a/src/components/Total.module.scss
+++ b/src/components/Total.module.scss
@@ -3,9 +3,6 @@
   position: fixed;
   max-width: 50rem;
   width: 100%;
-  min-height: 2rem;
-  height: max-content;
-  margin-top: 2.5rem;
   align-self: center;
   margin: auto;
   padding: 0;
@@ -20,8 +17,6 @@
   display: flex;
   position: relative;
   width: 100%;
-  min-height: 2rem;
-  height: max-content;
   align-self: center;
   align-items: flex-end;
   margin: auto;

--- a/src/components/Total.module.scss
+++ b/src/components/Total.module.scss
@@ -49,5 +49,7 @@
   }
   .total {
     flex-direction: column;
+    margin-left: 0;
+    margin-right: 0;
   }
 }

--- a/src/components/Total.module.scss
+++ b/src/components/Total.module.scss
@@ -1,24 +1,39 @@
-.total {
-  display: flex;
+.totalContainer {
+  display: block;
   position: fixed;
   max-width: 50rem;
+  width: 100%;
+  min-height: 2rem;
+  height: max-content;
+  margin-top: 2.5rem;
+  align-self: center;
+  margin: auto;
+  padding: 0;
+  padding-left: 2.25rem;
+  padding-right: 2.25rem;
+  bottom: 0;
+  overflow: hidden;
+  z-index: 200;
+}
+
+.total {
+  display: flex;
+  position: relative;
   width: 100%;
   min-height: 2rem;
   height: max-content;
   align-self: center;
   align-items: flex-end;
   margin: auto;
-  margin-top: 2.5rem;
+  margin-top: 2.5rem; // allows fade to peak above fold
   padding-top: 1rem;
   padding-bottom: 1rem;
-  padding-left: 1rem;
-  padding-right: 1rem;
-  bottom: 0;
+  padding-left: 0;
+  padding-right: 0;
   color: var(--secondary);
   background-color: var(--light);
   border-top: 0.1rem solid var(--secondary);
   box-shadow: 0 -0.5rem 0.75rem 0.5rem var(--light);
-  z-index: 200;
 }
 
 .totalTitle {
@@ -42,13 +57,6 @@
   height: max-content;
 }
 
-// Medium screen
-@media (max-width: 900px) {
-  .total {
-    max-width: none;
-  }
-}
-
 // Small screen
 @media (max-width: 600px) {
   .searchContainer {
@@ -56,7 +64,19 @@
     width: 100%;
   }
   .total {
-    max-width: none;
     flex-direction: column;
+  }
+  .totalContainer {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}
+
+// Medium screen
+@media (max-width: 900px) {
+  .totalContainer {
+    padding-left: 1rem;
+    padding-right: 1rem;
+    max-width: none;
   }
 }


### PR DESCRIPTION
On mobile browsers with a dynamic height (titlebar appears/disappears) the prompt menu's focus is displaced due to pos: "sticky". This makes it impossible to use the prompt menu on certain mobile browsers.

Fix: Switch to pos: "fixed"